### PR TITLE
[typo] Fix typo all->allow in Concurrency Cost Hierarchy Post

### DIFF
--- a/_posts/2020-07-06-concurrency-costs.md
+++ b/_posts/2020-07-06-concurrency-costs.md
@@ -259,7 +259,7 @@ Consider what happens when two threads, `A` and `B`, try to acquire the lock rep
 \\
 Of course, `B` is going to be a while: it needs to be woken by the scheduler and this takes a microsecond or two, at least. Now `B` wakes and gets the lock, and the same scenario repeats itself with the roles reversed. The upshot is that there is a full context switch for each acquisition of the lock.\\
 \\
-Unfair locks avoid this problem because they all queue jumping: in the scenario above, `A` (or any other thread) could re-acquire the lock after unlocking it, before `B` got its chance. So the use of the shared resource doesn't grind to a halt while `B` wakes up.
+Unfair locks avoid this problem because they allow queue jumping: in the scenario above, `A` (or any other thread) could re-acquire the lock after unlocking it, before `B` got its chance. So the use of the shared resource doesn't grind to a halt while `B` wakes up.
 {: .info}
 
 So, are you tired of seeing mostly-white plots where the newly introduced algorithm relegates the rest of the pack to little chunks of color near the x-axis, yet?


### PR DESCRIPTION
Fix a typo and transform "all" -> "allow" in Concurrency Cost Hierarchy Post

Apologies for not batching these up, but I'm making them as I read the post :)