### PR TITLE
Allow HTML and CSS by using sandboxed iframe

### DIFF
--- a/_includes/comment.html
+++ b/_includes/comment.html
@@ -16,6 +16,7 @@
 
   <div class="comment__body">
     <iframe src="about:blank" srcdoc="
+                                      <!DOCTYPE html>
                                       <html lang=en>
                                       <head>
                                       <meta charset=utf-8>

--- a/_includes/comment.html
+++ b/_includes/comment.html
@@ -15,7 +15,7 @@
   </div>
 
   <div class="comment__body">
-    <iframe src="data:text/html,{{ include.message | markdownify }}" srcdoc="{{ include.message | markdownify }}" height="200" style="border:none;width:100%"></iframe>
+    <iframe src='data:text/html,{{ include.message | markdownify }}' srcdoc='{{ include.message | markdownify }}' height="200" style="border:none;width:100%"></iframe>
   </div>
 
 {% if include.is_reply %}

--- a/_includes/comment.html
+++ b/_includes/comment.html
@@ -15,7 +15,18 @@
   </div>
 
   <div class="comment__body">
-    <iframe src="about:blank" srcdoc="<link rel=stylesheet href=https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css integrity=sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z crossorigin=anonymous> {{ include.message }}" height="200" title="Comment" style="border:none;width:100%"></iframe>
+    <iframe src="about:blank" srcdoc="
+                                      <html lang=en>
+                                      <head>
+                                      <meta charset=utf-8>
+                                      <title>Comment</title>
+                                      <base target=_top>
+                                      <link rel=stylesheet href=https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css integrity=sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z crossorigin=anonymous>
+                                      </head>
+                                      <body class=bg-transparent>
+                                      {{ include.message }}
+                                      </body>
+                                      </html>" height="200" title="Comment" style="border:none;width:100%"></iframe>
   </div>
 
 {% if include.is_reply %}

--- a/_includes/comment.html
+++ b/_includes/comment.html
@@ -15,7 +15,7 @@
   </div>
 
   <div class="comment__body">
-    <iframe src="about:blank" src="data:text/html,{{ include.message }}" srcdoc='{{ include.message }}' height="200" style="border:none;width:100%"></iframe>
+    <iframe src="about:blank" src="data:text/html,{{ include.message }}" srcdoc="{{ include.message }}" height="200" style="border:none;width:100%"></iframe>
   </div>
 
 {% if include.is_reply %}

--- a/_includes/comment.html
+++ b/_includes/comment.html
@@ -15,7 +15,7 @@
   </div>
 
   <div class="comment__body">
-    <iframe src='about:blank" srcdoc='{{ include.message }}' height="200" title="Comment" style="border:none;width:100%"></iframe>
+    <iframe src='about:blank" srcdoc='{{ include.message | markdownify }}' height="200" title="Comment" style="border:none;width:100%"></iframe>
   </div>
 
 {% if include.is_reply %}

--- a/_includes/comment.html
+++ b/_includes/comment.html
@@ -15,7 +15,7 @@
   </div>
 
   <div class="comment__body">
-    <iframe src="about:blank" src="data:text/html,{{ include.message | markdownify }}" srcdoc="{{ include.message | markdownify }}" height="200" style="border:none;width:100%"></iframe>
+    <iframe src="data:text/html,{{ include.message | markdownify }}" srcdoc="{{ include.message | markdownify }}" height="200" style="border:none;width:100%"></iframe>
   </div>
 
 {% if include.is_reply %}

--- a/_includes/comment.html
+++ b/_includes/comment.html
@@ -15,7 +15,7 @@
   </div>
 
   <div class="comment__body">
-    <iframe src="about:blank" srcdoc='<body style="margin:0;font-family:sans-serif;color:#333">{{ include.message }}</body>' height="200" style="border:none;width:100%" sandbox="allow-scripts allow-same-origin"></iframe>
+    <iframe src="about:blank" srcdoc='<body style="margin:0;font-family:sans-serif;color:#333">{{ include.message }}</body>' height="200" style="border:none;width:100%"></iframe>
   </div>
 
 {% if include.is_reply %}

--- a/_includes/comment.html
+++ b/_includes/comment.html
@@ -15,7 +15,7 @@
   </div>
 
   <div class="comment__body">
-    {{ include.message | strip_html | markdownify }}
+    <iframe src="about:blank" srcdoc='<body style="margin:0;font-family:sans-serif;color:#333">{{ include.message }}</body>' height="200" style="border:none;width:100%" sandbox></iframe>
   </div>
 
 {% if include.is_reply %}

--- a/_includes/comment.html
+++ b/_includes/comment.html
@@ -15,7 +15,7 @@
   </div>
 
   <div class="comment__body">
-    <iframe src='data:text/html,{{ include.message | markdownify }}' srcdoc='{{ include.message | markdownify }}' height="200" style="border:none;width:100%"></iframe>
+    <iframe src='about:blank" srcdoc='{{ include.message }}' height="200" title="Comment" style="border:none;width:100%"></iframe>
   </div>
 
 {% if include.is_reply %}

--- a/_includes/comment.html
+++ b/_includes/comment.html
@@ -15,7 +15,7 @@
   </div>
 
   <div class="comment__body">
-    <iframe src="about:blank" srcdoc="{{ include.message }}" height="200" title="Comment" style="border:none;width:100%"></iframe>
+    <iframe src="about:blank" srcdoc="<link rel=stylesheet href=https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css integrity=sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z crossorigin=anonymous> {{ include.message }}" height="200" title="Comment" style="border:none;width:100%"></iframe>
   </div>
 
 {% if include.is_reply %}

--- a/_includes/comment.html
+++ b/_includes/comment.html
@@ -15,7 +15,7 @@
   </div>
 
   <div class="comment__body">
-    <iframe src="about:blank" srcdoc="<!DOCTYPE html> <base target=_top> <link rel=stylesheet href=https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css integrity=sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z crossorigin=anonymous> {{ include.message }}" height="200" title="Comment" style="border:none;width:100%"></iframe>
+    <iframe src="about:blank" srcdoc="<link rel=stylesheet href=https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css integrity=sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z crossorigin=anonymous> {{ include.message }}" height="200" title="Comment" style="border:none;width:100%"></iframe>
   </div>
 
 {% if include.is_reply %}

--- a/_includes/comment.html
+++ b/_includes/comment.html
@@ -15,7 +15,7 @@
   </div>
 
   <div class="comment__body">
-    <iframe src='about:blank" srcdoc='{{ include.message | markdownify }}' height="200" title="Comment" style="border:none;width:100%"></iframe>
+    <iframe src='about:blank" srcdoc='{{ include.message }}' height="200" title="Comment" style="border:none;width:100%"></iframe>
   </div>
 
 {% if include.is_reply %}

--- a/_includes/comment.html
+++ b/_includes/comment.html
@@ -15,7 +15,7 @@
   </div>
 
   <div class="comment__body">
-    <iframe src="about:blank" srcdoc="<link rel=stylesheet href=https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css integrity=sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z crossorigin=anonymous> {{ include.message }}" height="200" title="Comment" style="border:none;width:100%"></iframe>
+    <iframe src="about:blank" srcdoc="<!DOCTYPE html> <base target=_top> <link rel=stylesheet href=https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css integrity=sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z crossorigin=anonymous> {{ include.message }}" height="200" title="Comment" style="border:none;width:100%"></iframe>
   </div>
 
 {% if include.is_reply %}

--- a/_includes/comment.html
+++ b/_includes/comment.html
@@ -15,7 +15,7 @@
   </div>
 
   <div class="comment__body">
-    <iframe src="about:blank" srcdoc='<body style="margin:0;font-family:sans-serif;color:#333">{{ include.message }}</body>' height="200" style="border:none;width:100%" sandbox></iframe>
+    <iframe src="about:blank" srcdoc='<body style="margin:0;font-family:sans-serif;color:#333">{{ include.message }}</body>' height="200" style="border:none;width:100%" sandbox="allow-scripts allow-same-origin"></iframe>
   </div>
 
 {% if include.is_reply %}

--- a/_includes/comment.html
+++ b/_includes/comment.html
@@ -15,7 +15,7 @@
   </div>
 
   <div class="comment__body">
-    <iframe src="about:blank" srcdoc='<body style="margin:0;font-family:sans-serif;color:#333">{{ include.message }}</body>' height="200" style="border:none;width:100%"></iframe>
+    <iframe src="about:blank" src="data:text/html,{{ include.message }}" srcdoc='{{ include.message }}' height="200" style="border:none;width:100%"></iframe>
   </div>
 
 {% if include.is_reply %}

--- a/_includes/comment.html
+++ b/_includes/comment.html
@@ -15,7 +15,7 @@
   </div>
 
   <div class="comment__body">
-    <iframe src='about:blank" srcdoc='{{ include.message }}' height="200" title="Comment" style="border:none;width:100%"></iframe>
+    <iframe src="about:blank" srcdoc="{{ include.message }}" height="200" title="Comment" style="border:none;width:100%"></iframe>
   </div>
 
 {% if include.is_reply %}

--- a/_includes/comment.html
+++ b/_includes/comment.html
@@ -15,7 +15,7 @@
   </div>
 
   <div class="comment__body">
-    <iframe src="about:blank" src="data:text/html,{{ include.message }}" srcdoc="{{ include.message }}" height="200" style="border:none;width:100%"></iframe>
+    <iframe src="about:blank" src="data:text/html,{{ include.message | markdownify }}" srcdoc="{{ include.message | markdownify }}" height="200" style="border:none;width:100%"></iframe>
   </div>
 
 {% if include.is_reply %}

--- a/_includes/comment_form.html
+++ b/_includes/comment_form.html
@@ -8,7 +8,7 @@
 
   <div class="textfield">
     <label for="comment-form-message"><h2>Add Comment<small><a rel="nofollow" id="cancel-comment-reply-link" href="{{ page.url | absolute_url }}#respond" style="display:none;">(cancel reply)</a></small></h2>
-      <textarea class="textfield__input" name="fields[message]" type="text" id="comment-form-message" placeholder="Your comment (Markdown, HTML and CSS accepted)" required rows="6"></textarea>
+      <textarea class="textfield__input" name="fields[message]" type="text" id="comment-form-message" placeholder="Your comment (HTML and CSS accepted)" required rows="6"></textarea>
     </label>
   </div>
 	

--- a/_includes/comment_form.html
+++ b/_includes/comment_form.html
@@ -14,6 +14,7 @@
 	
 	<script src="//cdn.ckeditor.com/4.14.1/standard/ckeditor.js"></script>
 	<script>
+		CKEDITOR.config.contentsCss = "https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css";
 		CKEDITOR.replace("comment-form-message");
 	</script>
 

--- a/_includes/comment_form.html
+++ b/_includes/comment_form.html
@@ -8,7 +8,7 @@
 
   <div class="textfield">
     <label for="comment-form-message"><h2>Add Comment<small><a rel="nofollow" id="cancel-comment-reply-link" href="{{ page.url | absolute_url }}#respond" style="display:none;">(cancel reply)</a></small></h2>
-      <textarea class="textfield__input" name="fields[message]" type="text" id="comment-form-message" placeholder="Your comment (HTML accepted)" required rows="6"></textarea>
+      <textarea class="textfield__input" name="fields[message]" type="text" id="comment-form-message" placeholder="Your comment (Markdown, HTML and CSS accepted)" required rows="6"></textarea>
     </label>
   </div>
 	

--- a/_includes/comment_form.html
+++ b/_includes/comment_form.html
@@ -8,7 +8,7 @@
 
   <div class="textfield">
     <label for="comment-form-message"><h2>Add Comment<small><a rel="nofollow" id="cancel-comment-reply-link" href="{{ page.url | absolute_url }}#respond" style="display:none;">(cancel reply)</a></small></h2>
-      <textarea class="textfield__input" name="fields[message]" type="text" id="comment-form-message" placeholder="Your comment (markdown accepted)" required rows="6"></textarea>
+      <textarea class="textfield__input" name="fields[message]" type="text" id="comment-form-message" placeholder="Your comment (HTML accepted)" required rows="6"></textarea>
     </label>
   </div>
 	

--- a/_includes/comment_form.html
+++ b/_includes/comment_form.html
@@ -11,6 +11,11 @@
       <textarea class="textfield__input" name="fields[message]" type="text" id="comment-form-message" placeholder="Your comment (markdown accepted)" required rows="6"></textarea>
     </label>
   </div>
+	
+	<script src="//cdn.ckeditor.com/4.14.1/standard/ckeditor.js"></script>
+	<script>
+		CKEDITOR.replace("comment-form-message");
+	</script>
 
     <div class="textfield narrowfield">
       <label for="comment-form-name">Name


### PR DESCRIPTION
Currently, you strip HTML from comments. However, Markdown doesn't support CSS styling, YouTube embedding and other cool stuff.

This solution uses an `iframe` to load the comments instead. This allows use of HTML and CSS, while using iframes to keep the parent page secure from XSS vulnerabilities.

Even if you might not think you'd like it, **please, please give it a try**.